### PR TITLE
Update variable syntax to more recent Ansible conventions.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,28 +20,28 @@
 - name: "fetch npi plugins"
   shell: npi fetch "{{item.key}}" -y
     creates="{{npi_prefix}}/plugins/{{item.key}}"
-  with_dict: npi_plugins
+  with_dict: "{{npi_plugins}}"
 - name: "get plugin location"
   shell: "npi where {{item.key}}"
   register: npi_plugin_locations
-  with_dict: npi_plugins
+  with_dict: "{{npi_plugins}}"
   changed_when: no
 - name: "add plugin services"
   template:
     src=npi-plugin-upstart.conf.j2
     dest=/etc/init/{{item.key}}.conf
-  with_dict: npi_plugins
+  with_dict: "{{npi_plugins}}"
 - name: "add newrelic configs"
   template:
     src="newrelic.json.j2"
     dest="{{item.stdout}}/config/newrelic.json"
-  with_items: npi_plugin_locations.results
+  with_items: "{{npi_plugin_locations.results}}"
 - name: "add plugin configs"
   template:
     src="{{npi_plugins[item.item].template}}"
     dest="{{item.stdout}}/config/plugin.json"
   when: npi_plugins[item.item].template is defined
-  with_items: npi_plugin_locations.results
+  with_items: "{{npi_plugin_locations.results}}"
 - name: "restart plugin services"
   service: name="{{item.key}}" state=restarted
-  with_dict: npi_plugins
+  with_dict: "{{npi_plugins}}"


### PR DESCRIPTION
Newer versions of Ansible throw deprecation warnings, like so:

![image](https://cloud.githubusercontent.com/assets/2030693/18109736/e79b23fc-6ed8-11e6-9834-4a2a181715b3.png)

This simple change gets the role back up to speed.
